### PR TITLE
Add stats endpoint and sync counters

### DIFF
--- a/rivian.py
+++ b/rivian.py
@@ -11,7 +11,10 @@ load_dotenv()
 
 app = Flask(__name__)
 
-STATS_FILE = "rivian_stats.json"
+# Ensure stats file path is absolute so it works regardless of the
+# current working directory (useful in serverless environments).
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+STATS_FILE = os.path.join(BASE_DIR, "rivian_stats.json")
 
 # --- Helper Functions for Stats ---
 
@@ -92,6 +95,27 @@ def index():
         "most_in_a_day": stats.get("daily_max", {}).get("count", 0)
     }
     return render_template('index.html', **template_data)
+
+
+@app.route('/stats', methods=['GET'])
+def stats_endpoint():
+    """Return the latest counters for use by the frontend."""
+    stats = read_stats()
+    now = datetime.now()
+    current_month_str = now.strftime("%Y-%m")
+
+    monthly_stats = stats.get("monthly", {}).get(current_month_str, {"krystian": 0, "jensen": 0, "total": 0})
+
+    response = {
+        "total_all_time": stats.get("total_all_time", 0),
+        "krystian_all_time": stats.get("krystian_all_time", 0),
+        "jensen_all_time": stats.get("jensen_all_time", 0),
+        "total_this_month": monthly_stats.get("total", 0),
+        "krystian_this_month": monthly_stats.get("krystian", 0),
+        "jensen_this_month": monthly_stats.get("jensen", 0),
+        "most_in_a_day": stats.get("daily_max", {}).get("count", 0)
+    }
+    return jsonify(response)
 
 @app.route('/buy_rivn', methods=['POST'])
 def buy_rivn():

--- a/templates/index.html
+++ b/templates/index.html
@@ -251,6 +251,41 @@
         // Removed unused global clickCount variable
         // let clickCount = 0;
 
+        // When the page loads, populate counters from localStorage if present
+        document.addEventListener('DOMContentLoaded', () => {
+            const saved = localStorage.getItem('rivian-stats');
+            if (saved) {
+                try {
+                    const stats = JSON.parse(saved);
+                    document.getElementById('total-all-time').textContent = stats.total_all_time ?? 0;
+                    document.getElementById('total-month').textContent = stats.total_this_month ?? 0;
+                    document.getElementById('krystian-all-time').textContent = stats.krystian_all_time ?? 0;
+                    document.getElementById('jensen-all-time').textContent = stats.jensen_all_time ?? 0;
+                    document.getElementById('krystian-month').textContent = stats.krystian_this_month ?? 0;
+                    document.getElementById('jensen-month').textContent = stats.jensen_this_month ?? 0;
+                    document.getElementById('most-day').textContent = stats.most_in_a_day ?? 0;
+                } catch (e) {
+                    console.warn('Failed to parse stored stats', e);
+                }
+            }
+
+            // Always fetch the latest stats from the server so different
+            // browsers stay in sync. Update the display and localStorage.
+            fetch('/stats')
+                .then(r => r.json())
+                .then(stats => {
+                    document.getElementById('total-all-time').textContent = stats.total_all_time ?? 0;
+                    document.getElementById('total-month').textContent = stats.total_this_month ?? 0;
+                    document.getElementById('krystian-all-time').textContent = stats.krystian_all_time ?? 0;
+                    document.getElementById('jensen-all-time').textContent = stats.jensen_all_time ?? 0;
+                    document.getElementById('krystian-month').textContent = stats.krystian_this_month ?? 0;
+                    document.getElementById('jensen-month').textContent = stats.jensen_this_month ?? 0;
+                    document.getElementById('most-day').textContent = stats.most_in_a_day ?? 0;
+                    localStorage.setItem('rivian-stats', JSON.stringify(stats));
+                })
+                .catch(err => console.warn('Failed to fetch stats', err));
+        });
+
         // createConfetti function now accepts rocketCount
         function createConfetti(buttonElement, rocketCount) { 
             const buttonRect = buttonElement.getBoundingClientRect();
@@ -320,6 +355,9 @@
                         document.getElementById('krystian-month').textContent = data.updated_stats.krystian_this_month ?? 0;
                         document.getElementById('jensen-month').textContent = data.updated_stats.jensen_this_month ?? 0;
                         document.getElementById('most-day').textContent = data.updated_stats.most_in_a_day ?? 0;
+
+                        // Persist counters locally so they survive page refresh
+                        localStorage.setItem('rivian-stats', JSON.stringify(data.updated_stats));
 
                         // Create confetti based on the specific user's new all-time count
                         const userSpecificAllTimeCount = data.user_new_all_time_count ?? 0; // Get the count from response


### PR DESCRIPTION
## Summary
- create a `/stats` route to return current totals
- fetch `/stats` on page load so all browsers stay in sync

## Testing
- `python -m py_compile rivian.py`
